### PR TITLE
Refactor the patch and run Python scripts

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,64 +1,156 @@
-import os
-import shutil
-import urllib.request
-import zipfile
+import argparse
+from os import environ
 from pathlib import Path
-import platform
-import utils
+from run import run_game
+import shutil
+import subprocess
+import sys
+import urllib.request
+from utils import run_exe, get_nerts_path, remove_existing_path
+import zipfile
 
-system = platform.system()
 
-BIN_PATH = Path("bin")
+DE4DOT_URL = "https://github.com/ViRb3/de4dot-cex/releases/download/v4.0.0/de4dot-cex.zip"
 
-if not "SKIP_DOWNLOAD" in os.environ:
-  try:
-    if BIN_PATH.exists():
-      shutil.rmtree(BIN_PATH)
-  except:
-    print("Unable to clear bin/ directory, aborting.")
-    quit()
 
-  BIN_PATH.mkdir()
+def download_de4dot(bin_dir: Path) -> None:
+    """
+    Downloads de4dot to the bin dir and extracts it.
+    """
 
-  # Download de4dot
-  urllib.request.urlretrieve("https://github.com/ViRb3/de4dot-cex/releases/download/v4.0.0/de4dot-cex.zip", BIN_PATH / "de4dot-cex.zip")
+    # Download de4dot to the bin dir
+    urllib.request.urlretrieve(DE4DOT_URL, bin_dir / "de4dot-cex.zip")
 
-  # Extract de4dot
-  with zipfile.ZipFile(BIN_PATH / "de4dot-cex.zip", "r") as zip:
-    zip.extractall("bin/")
+    # Extract de4dot
+    with zipfile.ZipFile(bin_dir / "de4dot-cex.zip", "r") as zip:
+        zip.extractall(bin_dir)
 
-nertsPath = utils.get_nerts_path()
-cleanedName = f"{nertsPath.stem}-cleaned.exe"
-actualName = "NertsOnline-cleaned.exe"
+    # Attempt to remove zip file
+    (bin_dir / "de4dot-cex.zip").unlink()
 
-# Run de4dot to deobfuscate executable
-utils.run_exe(BIN_PATH / "de4dot-x64.exe", "\"" + str(nertsPath) + "\"")
-shutil.copyfile(nertsPath.parent / cleanedName, Path("bin") / actualName)
 
-# Build and run patcher
-os.chdir("Patcher")
-os.system("dotnet build")
-utils.run_exe(BIN_PATH / "Debug/net452/NertsPlusPatcher.exe")
-shutil.copyfile(BIN_PATH / "Debug/net452/NertsPlusPatcher.exe", os.path.dirname(nertsPath) + "/NertsPlusPatcher.exe")
-os.chdir("..")
+def run_de4dot(bin_dir: Path, nerts_path: Path, cleaned_name: str) -> None:
+    """
+    Runs de4dot to deobfuscate the Nerts game executable.
+    """
 
-# Copy patcher output back to Steam directory
-shutil.copyfile(BIN_PATH / "NertsOnline-patched.exe", os.path.dirname(nertsPath) + "/NertsOnline-patched.exe")
+    run_exe(bin_dir / "de4dot-x64.exe", [str(nerts_path)])
+    shutil.copyfile(nerts_path.parent / cleaned_name, bin_dir / "NertsOnline-cleaned.exe")
 
-# Build and copy plugin
-os.chdir("Plugin")
-os.system("dotnet build")
-shutil.copyfile(BIN_PATH / "Debug/net452/NertsPlus.dll", os.path.dirname(nertsPath) + "/NertsPlus.dll")
-shutil.copyfile(BIN_PATH / "Debug/net452/0Harmony.dll", os.path.dirname(nertsPath) + "/0Harmony.dll")
-shutil.copyfile(BIN_PATH / "Debug/net452/Newtonsoft.Json.dll", os.path.dirname(nertsPath) + "/Newtonsoft.Json.dll")
-os.chdir("..")
 
-# Write steam_appid.txt file
-with open(os.path.dirname(nertsPath) + "/steam_appid.txt", "w") as file:
-  file.write("1131190")
+def build_patcher() -> None:
+    """
+    Builds the patcher and copies it to the Nerts game folder.
+    """
+    patcher_dir = Path().cwd() / "Patcher"
 
-# Finally, copy textures...
-shutil.copyfile("textures/logo_button.tex", os.path.dirname(nertsPath) + "/Content/Packed/logo_button.tex")
-shutil.copyfile("textures/logo_button_hover.tex", os.path.dirname(nertsPath) + "/Content/Packed/logo_button_hover.tex")
+    subprocess.call("dotnet run", cwd=patcher_dir)
 
-print("🎉 All done! To finish, drop NertsPlus.dll in to " + os.path.dirname(nertsPath) + ", and then execute run.py")
+
+def run_patcher(bin_dir: Path, nerts_path: Path) -> None:
+    """
+    Runs the patcher to patch the Nerts game executable, and then copies it to the Nerts game folder.
+    """
+    patcher_dir = Path().cwd() / "Patcher"
+
+    run_exe(Path("bin") / "Debug/net452/NertsPlusPatcher.exe", cwd=patcher_dir)
+    shutil.copyfile(patcher_dir / "bin/Debug/net452/NertsPlusPatcher.exe", nerts_path.parent / "NertsPlusPatcher.exe")
+
+    # Copy patcher output back to Steam directory
+    shutil.copyfile(bin_dir / "NertsOnline-patched.exe", nerts_path.parent / "NertsOnline-patched.exe")
+
+
+def build_plugin(nerts_path: Path) -> None:
+
+    plugin_dir = Path().cwd() / "Plugin"
+
+    # Build and copy plugin
+    run_exe("dotnet", ["build"], cwd=plugin_dir)
+    shutil.copyfile(plugin_dir / "bin/Debug/net452/NertsPlus.dll", nerts_path.parent / "NertsPlus.dll")
+    shutil.copyfile(plugin_dir / "bin/Debug/net452/0Harmony.dll", nerts_path.parent / "0Harmony.dll")
+    shutil.copyfile(plugin_dir / "bin/Debug/net452/Newtonsoft.Json.dll", nerts_path.parent / "Newtonsoft.Json.dll")
+
+
+def write_steam_appid(nerts_path: Path) -> None:
+    """
+    Writes the steam_appid.txt file to the Nerts game folder.
+    """
+
+    NERTS_STEAM_ID = "1131190"
+
+    with open(nerts_path.parent / "steam_appid.txt", "w") as file:
+        file.write(NERTS_STEAM_ID)
+
+
+def copy_textures(nerts_path: Path) -> None:
+    """
+    Copies the textures to the Nerts game folder.
+    """
+
+    shutil.copyfile("textures/logo_button.tex", nerts_path.parent / "Content/Packed/logo_button.tex")
+    shutil.copyfile("textures/logo_button_hover.tex", nerts_path.parent / "Content/Packed/logo_button_hover.tex")
+
+
+def main():
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="NertsPlus patcher")
+    parser.add_argument(
+        "--skip-download",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Skip downloading and extracting de4dot")
+    parser.add_argument(
+        "-b",
+        "--bin-dir",
+        type=Path,
+        default=Path("bin"),
+        help="Directory to store de4dot and patched binaries")
+    parser.add_argument(
+        "-n",
+        "--nerts-path",
+        type=Path,
+        help="Path to Nerts game executable")
+    parser.add_argument(
+        "-r",
+        "--run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run the game")
+
+    args = parser.parse_args()
+
+    # If a nerts path is not provided, try to find it automatically
+    # or ask for user input
+    if args.nerts_path is None:
+        nerts_path = get_nerts_path()
+    else:
+        nerts_path = args.nerts_path
+    cleaned_name = f"{nerts_path.stem}-cleaned.exe"
+
+    if args.run:
+        run_game(nerts_path)
+        sys.exit(0)
+
+    if not (args.skip_download or environ.get("SKIP_DOWNLOAD")):
+        if not remove_existing_path(args.bin_dir):
+            print("Unable to clear the bin directory, aborting 🛑!")
+            sys.exit(1)
+
+        args.bin_dir.mkdir()
+
+        # Download de4dot
+        download_de4dot(args.bin_dir)
+
+    run_de4dot(args.bin_dir, nerts_path, cleaned_name)
+    build_patcher()
+    run_patcher(args.bin_dir, nerts_path)
+    build_plugin(nerts_path)
+    copy_textures(args.bin_dir, nerts_path)
+    write_steam_appid(nerts_path)
+
+    print("🎉 All done! Now re-run with the --run flag to run the game.")
+
+
+if __name__ == "__main__":
+    main()

--- a/patch.py
+++ b/patch.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 import urllib.request
-from utils import run_exe, get_nerts_path, remove_existing_path
+from utils import run_command, run_exe, get_nerts_path, remove_existing_path
 import zipfile
 
 
@@ -44,7 +44,7 @@ def build_patcher() -> None:
     """
     patcher_dir = Path().cwd() / "Patcher"
 
-    subprocess.call("dotnet run", cwd=patcher_dir)
+    subprocess.call("dotnet build", cwd=patcher_dir, shell=True)
 
 
 def run_patcher(bin_dir: Path, nerts_path: Path) -> None:
@@ -65,7 +65,7 @@ def build_plugin(nerts_path: Path) -> None:
     plugin_dir = Path().cwd() / "Plugin"
 
     # Build and copy plugin
-    run_exe("dotnet", ["build"], cwd=plugin_dir)
+    run_command("dotnet", ["build"], cwd=plugin_dir)
     shutil.copyfile(plugin_dir / "bin/Debug/net452/NertsPlus.dll", nerts_path.parent / "NertsPlus.dll")
     shutil.copyfile(plugin_dir / "bin/Debug/net452/0Harmony.dll", nerts_path.parent / "0Harmony.dll")
     shutil.copyfile(plugin_dir / "bin/Debug/net452/Newtonsoft.Json.dll", nerts_path.parent / "Newtonsoft.Json.dll")
@@ -146,7 +146,7 @@ def main():
     build_patcher()
     run_patcher(args.bin_dir, nerts_path)
     build_plugin(nerts_path)
-    copy_textures(args.bin_dir, nerts_path)
+    copy_textures(nerts_path)
     write_steam_appid(nerts_path)
 
     print("🎉 All done! Now re-run with the --run flag to run the game.")

--- a/run.py
+++ b/run.py
@@ -1,12 +1,17 @@
-import os
+from pathlib import Path
 import platform
-import utils
+from utils import run_exe, get_nerts_path
 
 system = platform.system()
 
-if system == "Darwin":
-  os.chdir(os.path.dirname(utils.get_nerts_path()) + "/osx")
-  utils.run_exe("../NertsOnline-patched.exe")
-else:
-  os.chdir(os.path.dirname(utils.get_nerts_path()))
-  utils.run_exe("NertsOnline-patched.exe")
+
+def run_game(nerts_path: Path):
+    if system == "Darwin":
+        run_exe("../NertsOnline-patched.exe", cwd=(nerts_path.parent / "osx"))
+    else:
+        run_exe("NertsOnline-patched.exe", cwd=(nerts_path.parent))
+
+
+if __name__ == "__main__":
+    nerts_path = get_nerts_path()
+    run_game(nerts_path)

--- a/utils.py
+++ b/utils.py
@@ -1,34 +1,63 @@
 import os
+import subprocess
 from pathlib import Path
+import shutil
 import platform
+import sys
 
 system = platform.system()
 
-def get_nerts_path():
-  # Try to find where Nerts is installed
-  if system == "Darwin":
-    nertsPath = Path(os.path.join(os.path.expanduser('~'), "Library/Application Support/Steam/steamapps/common/Nerts Online/NERTS! Online.app/Contents/MacOS/NertsOnline.exe"))
-  elif system == "Windows":
-    nertsPath = Path("C:/Program Files (x86)/Steam/steamapps/common/Nerts Online/NERTS! Online.exe")
 
-  while nertsPath is None or not nertsPath.exists():
+def remove_existing_path(path: Path) -> bool:
+    """
+    Removes a pathlib.Path if it exists.
+
+    returns:
+        - True on success,
+        - False on rmtree error
+    """
+
     try:
-      nertsPath = Path(input("Please enter the path to NertsOnline.exe: "))
-    except KeyboardInterrupt:
-      quit()
-    except:
-      print("")
-      pass
+        if path.exists():
+            shutil.rmtree(path)
+    except Exception:
+        return False
 
-  return nertsPath
+    return True
 
-def run_exe(path, args = None):
-  command = str(path)
 
-  if not args is None:
-    command = command + " " + args
+def get_nerts_path():
+    # Try to find where Nerts is installed
+    if system == "Darwin":
+        nertsPath = Path(os.path.join(os.path.expanduser('~'), "Library/Application Support/Steam/steamapps/common/Nerts Online/NERTS! Online.app/Contents/MacOS/NertsOnline.exe"))
+    elif system == "Windows":
+        nertsPath = Path("C:/Program Files (x86)/Steam/steamapps/common/Nerts Online/NERTS! Online.exe")
 
-  if system == "Darwin":
-    os.system("mono64 " + command)
-  else:
-    os.system(command)
+    while nertsPath is None or not nertsPath.exists():
+        try:
+            nertsPath = Path(input("Please enter the path to NertsOnline.exe: "))
+        except KeyboardInterrupt:
+            sys.exit()
+        except Exception as e:
+            print(e)
+
+    return nertsPath
+
+
+def run_exe(path, args: list[str] = None, cwd=None):
+    command = str(path)
+
+    if args is None:
+        args = []
+
+    if cwd is None:
+        cwd = Path().cwd()
+
+    command_list = [command] + args
+
+    print(f"running {command_list} from {cwd}")
+
+    if system == "Darwin":
+        command_list.insert(0, "mono64")
+
+    subprocess.call(command_list, cwd=cwd, shell=True)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 import shutil
+import shlex
 import platform
 import sys
 
@@ -44,20 +45,22 @@ def get_nerts_path():
     return nertsPath
 
 
-def run_exe(path, args: list[str] = None, cwd=None):
-    command = str(path)
+def run_exe(path, args: list[str] = [], cwd=None):
+    if system == "Darwin":
+        run_command("mono64", [str(path)] + args, cwd)
+    else:
+        run_command(path, args, cwd)
 
-    if args is None:
-        args = []
+
+def run_command(path, args: list[str] = [], cwd=None):
+    command = str(path)
 
     if cwd is None:
         cwd = Path().cwd()
 
     command_list = [command] + args
 
-    print(f"running {command_list} from {cwd}")
+    command_str = ' '.join(shlex.quote(arg) for arg in command_list)
+    print(f"running {command_str} from {cwd}")
 
-    if system == "Darwin":
-        command_list.insert(0, "mono64")
-
-    subprocess.call(command_list, cwd=cwd, shell=True)
+    subprocess.call([command_str], cwd=cwd, shell=True)

--- a/utils.py
+++ b/utils.py
@@ -60,7 +60,10 @@ def run_command(path, args: list[str] = [], cwd=None):
 
     command_list = [command] + args
 
-    command_str = ' '.join(shlex.quote(arg) for arg in command_list)
-    print(f"running {command_str} from {cwd}")
-
-    subprocess.call([command_str], cwd=cwd, shell=True)
+    if system == "Darwin":
+        command_str = ' '.join(shlex.quote(arg) for arg in command_list)
+        print(f"running {command_str} from {cwd}")
+        subprocess.call([command_str], cwd=cwd, shell=True)
+    else:
+        print(f"running {command_list} from {cwd}")
+        subprocess.call(command_list, cwd=cwd, shell=True)


### PR DESCRIPTION
This commit refactors the patch.py script to be nicer to work on 😋

There are now command line arguments for patch.py:
 --run: "Run the patched Nerts executable"
    (Note: run.py still works as before)
 --nerts_path: "Path to the Nerts executable"
 --skip_download: "Skip downloading de4dot"
 --bin-dir: "Directory to store de4dot and temporary executables" (This is slightly broken, it only works with absolute paths)

I haven't tested this on Linux or MacOS yet (cc @oliverdunk).

Thanks